### PR TITLE
Implement simple excaldraw clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# chatgpt
+# Excalidraw Clone
+
+This repository contains a simple web-based drawing application inspired by [Excalidraw](https://excalidraw.com/). It provides basic shape drawing functionality using the HTML5 canvas element.
+
+## Usage
+
+Open `index.html` in a modern web browser to start drawing.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Excalidraw Clone</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="toolbar">
+        <button id="pencil" class="active">Pencil</button>
+        <button id="rectangle">Rectangle</button>
+        <button id="line">Line</button>
+        <button id="clear">Clear</button>
+    </div>
+    <canvas id="canvas" width="800" height="600"></canvas>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,94 @@
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+
+let tool = 'pencil';
+let drawing = false;
+let startX = 0;
+let startY = 0;
+let shapes = [];
+
+function setActive(buttonId) {
+    document.querySelectorAll('#toolbar button').forEach(btn => btn.classList.remove('active'));
+    document.getElementById(buttonId).classList.add('active');
+}
+
+function drawAll() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    shapes.forEach(shape => {
+        if (shape.type === 'line') {
+            ctx.beginPath();
+            ctx.moveTo(shape.x1, shape.y1);
+            ctx.lineTo(shape.x2, shape.y2);
+            ctx.stroke();
+        } else if (shape.type === 'rect') {
+            ctx.strokeRect(shape.x, shape.y, shape.w, shape.h);
+        } else if (shape.type === 'path') {
+            ctx.beginPath();
+            shape.points.forEach((p, i) => {
+                if (i === 0) ctx.moveTo(p.x, p.y);
+                else ctx.lineTo(p.x, p.y);
+            });
+            ctx.stroke();
+        }
+    });
+}
+
+canvas.addEventListener('mousedown', (e) => {
+    drawing = true;
+    startX = e.offsetX;
+    startY = e.offsetY;
+    if (tool === 'pencil') {
+        shapes.push({ type: 'path', points: [{ x: startX, y: startY }] });
+    }
+});
+
+canvas.addEventListener('mousemove', (e) => {
+    if (!drawing) return;
+    const x = e.offsetX;
+    const y = e.offsetY;
+    if (tool === 'pencil') {
+        const path = shapes[shapes.length - 1];
+        path.points.push({ x, y });
+        drawAll();
+    } else {
+        drawAll();
+        if (tool === 'rect') {
+            ctx.strokeRect(startX, startY, x - startX, y - startY);
+        } else if (tool === 'line') {
+            ctx.beginPath();
+            ctx.moveTo(startX, startY);
+            ctx.lineTo(x, y);
+            ctx.stroke();
+        }
+    }
+});
+
+canvas.addEventListener('mouseup', (e) => {
+    if (!drawing) return;
+    drawing = false;
+    const x = e.offsetX;
+    const y = e.offsetY;
+    if (tool === 'rect') {
+        shapes.push({ type: 'rect', x: startX, y: startY, w: x - startX, h: y - startY });
+    } else if (tool === 'line') {
+        shapes.push({ type: 'line', x1: startX, y1: startY, x2: x, y2: y });
+    }
+    drawAll();
+});
+
+canvas.addEventListener('mouseleave', () => {
+    drawing = false;
+});
+
+// Toolbar actions
+['pencil', 'rectangle', 'line'].forEach(id => {
+    document.getElementById(id).addEventListener('click', () => {
+        tool = id === 'rectangle' ? 'rect' : id;
+        setActive(id);
+    });
+});
+
+document.getElementById('clear').addEventListener('click', () => {
+    shapes = [];
+    drawAll();
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,28 @@
+body {
+    font-family: Arial, sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 0;
+    padding: 0;
+    height: 100vh;
+}
+
+#toolbar {
+    margin: 10px;
+}
+
+button {
+    margin-right: 5px;
+    padding: 5px 10px;
+}
+
+canvas {
+    border: 1px solid #ccc;
+    cursor: crosshair;
+}
+
+button.active {
+    background-color: #007bff;
+    color: white;
+}


### PR DESCRIPTION
## Summary
- describe how to open the drawing app
- implement a basic Excalidraw-like drawing board with HTML canvas
- add simple styling and drawing logic
- correct spelling of the project title

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844f40dd64883269502168e7a420e1e